### PR TITLE
Remove empty targets from lightningcss minimizer

### DIFF
--- a/src/common/webpack/config.ts
+++ b/src/common/webpack/config.ts
@@ -1343,12 +1343,7 @@ function configureRspackOptimization(
     let cssMinimizer: Rspack.Plugin;
 
     if (config.transformCssWithLightningCss) {
-        cssMinimizer = new rspack.LightningCssMinimizerRspackPlugin({
-            minimizerOptions: {
-                // Plugin will read the browserslist itself and generate targets
-                targets: [],
-            },
-        });
+        cssMinimizer = new rspack.LightningCssMinimizerRspackPlugin();
     } else {
         const CssMinimizerPlugin: typeof CssMinimizerWebpackPlugin = require('css-minimizer-webpack-plugin');
         cssMinimizer = new CssMinimizerPlugin({


### PR DESCRIPTION
Empty targets list works as "no browser at all": see [how it works](https://lightningcss.dev/playground/index.html#%7B%22minify%22%3Afalse%2C%22customMedia%22%3Atrue%2C%22cssModules%22%3Afalse%2C%22analyzeDependencies%22%3Afalse%2C%22targets%22%3A%7B%7D%2C%22include%22%3A0%2C%22exclude%22%3A0%2C%22source%22%3A%22.foo%20%7B%5Cn%20%20%20%20width%3A%20100%25%3B%5Cn%20%20%20%20width%3A%20stretch%3B%5Cn%20%20%20%20width%3A%20-webkit-fill-available%3B%5Cn%20%20%20%20width%3A%20-moz-available%3B%5Cn%7D%5Cn%22%2C%22visitorEnabled%22%3Afalse%2C%22visitor%22%3A%22%7B%5Cn%20%20Color(color)%20%7B%5Cn%20%20%20%20if%20(color.type%20%3D%3D%3D%20'rgb')%20%7B%5Cn%20%20%20%20%20%20color.g%20%3D%200%3B%5Cn%20%20%20%20%20%20return%20color%3B%5Cn%20%20%20%20%7D%5Cn%20%20%7D%5Cn%7D%22%2C%22unusedSymbols%22%3A%5B%5D%2C%22version%22%3A%22local%22%7D) for multiple width declarations.